### PR TITLE
add: user destroy function and test

### DIFF
--- a/src/app/Http/Controllers/ProgressController.php
+++ b/src/app/Http/Controllers/ProgressController.php
@@ -183,17 +183,17 @@ class ProgressController extends Controller
         if($progress){
             if($user->id != $progress->user_id){
                 // 自分の進捗IDではない場合
-                $session_name = "status-error";
-                $session_message = "他人の進捗は削除できません。";
+                $session_name = 'status-error';
+                $session_message = '他人の進捗は削除できません。';
             }else{
                 // 進捗削除処理
                 Progress::destroy($progress->id);
-                $session_name = "status";
+                $session_name = 'status';
                 $session_message = '進捗（'.$progress->action.'）を削除しました。';
             }
         }else{
-            $session_name = "status-error";
-            $session_message = "進捗の削除処理に失敗しました。";
+            $session_name = 'status-error';
+            $session_message = '進捗の削除処理に失敗しました。';
         }
         return redirect()->back()->with($session_name,$session_message);
     }

--- a/src/app/Http/Controllers/UsersController.php
+++ b/src/app/Http/Controllers/UsersController.php
@@ -16,8 +16,8 @@ class UsersController extends Controller
      */
     public function create()
     {
-        $user = Auth::user();
-        if($user->is_teacher){
+        $login_user = Auth::user();
+        if($login_user->is_teacher){
             return view('users/create');
         }
         return redirect()->route('home');
@@ -29,36 +29,51 @@ class UsersController extends Controller
      */
     public function store(Request $request)
     {
-        $user = Auth::user();
-        if($user->is_teacher){
-            $request->validate([
-                'attend_num' => ['required','integer','min:1','max:50'],
-                'name' => ['required', 'string', 'max:255'],
-                'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-                'password' => ['required', 'string', 'min:8', 'confirmed'],
-            ],[
-                'name.required' => '生徒名は必須項目です。',
-                'attend_num.required' => '出席番号は必須です。',
-                'attend_num.max' => '出席番号は50より小さい数にしてください。',
-                'attend_num.min' => '出席番号は1以上です。',
-                'email.required'  => 'メールアドレスは必須項目です。',
-                'email.email'  => 'メールアドレスを入力してください。',
-                'password.required'  => 'パスワードは必須項目です。',
-            ]);
+        $login_user = Auth::user();
+        if($login_user->is_teacher){
 
-            User::create([
-                'name' => $request->input('name'),
-                'attend_num' => $request->input('attend_num'),
-                'email' => $request->input('email'),
-                'password' => Hash::make($request->input('passowrod')),
-                'is_teacher' => 0,
-                'teacher_id' => $user->id,
-            ]);
+            $session_name = '';
+            $session_message = '';
+
+            $deleted_student = User::onlyTrashed()->where('email',$request->email)->first();
+            if($deleted_student){
+                // 過去に削除されている場合 生徒を復元
+                $deleted_student->restore();
+                $session_name = 'status';
+                $session_message = '生徒（'.$deleted_student->name.'）を復元しました。';
+            }else{
+                // 生徒を新規作成
+                $request->validate([
+                    'attend_num' => ['required','integer','min:1','max:50'],
+                    'name' => ['required', 'string', 'max:255'],
+                    'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+                    'password' => ['required', 'string', 'min:8', 'confirmed'],
+                ],[
+                    'name.required' => '生徒名は必須項目です。',
+                    'attend_num.required' => '出席番号は必須です。',
+                    'attend_num.max' => '出席番号は50より小さい数にしてください。',
+                    'attend_num.min' => '出席番号は1以上です。',
+                    'email.required'  => 'メールアドレスは必須項目です。',
+                    'email.email'  => 'メールアドレスを入力してください。',
+                    'password.required'  => 'パスワードは必須項目です。',
+                ]);
+
+                User::create([
+                    'name' => $request->input('name'),
+                    'attend_num' => $request->input('attend_num'),
+                    'email' => $request->input('email'),
+                    'password' => Hash::make($request->input('passowrod')),
+                    'is_teacher' => 0,
+                    'teacher_id' => $login_user->id,
+                ]);
+                $session_name = 'status';
+                $session_message = '生徒（'.$request->name.'）を登録しました。';
+            }
         }else{
-            return redirect()->route('home')
-            ->with('status-error','あなたは教師ではないので生徒を登録することはできません。');
+            $session_name = 'status-error';
+            $session_message = 'あなたは教師ではないので生徒を登録することはできません。';
         }
-        return redirect()->route('home');
+        return redirect()->route('home')->with($session_name,$session_message);
     }
 
 
@@ -106,6 +121,31 @@ class UsersController extends Controller
      */
     public function destroy($id)
     {
-        //
+        $login_user = Auth::user();
+        if(!($login_user->is_teacher)){
+            return redirect('home');
+        }
+
+        $student = User::find($id);
+        $session_name = '';
+        $session_message = '';
+
+        if($student){
+            // 削除対象生徒が存在する場合
+            if($student->teacher_id == $login_user->id){
+                // 削除対象生徒がログインユーザーの生徒の場合
+                User::destroy($id);
+                $session_name = 'status';
+                $session_message = '生徒（'. $student->name .'）を削除しました。';
+            }else{
+                // 削除対象生徒が存在するが、ログインユーザの生徒ではない場合
+                $session_name = 'status-error';
+                $session_message = '削除対象の生徒が自分の生徒ではない為、処理が失敗しました。';
+            }
+        }else{
+            $session_name = 'status-error';
+            $session_message = '削除対象の生徒が存在しない為、処理が失敗しました。';
+        }
+        return redirect()->back()->with($session_name,$session_message);
     }
 }

--- a/src/database/seeds/EntriesTableSeeder.php
+++ b/src/database/seeds/EntriesTableSeeder.php
@@ -14,7 +14,7 @@ class EntriesTableSeeder extends Seeder
     {
         for ($i = 1; $i<=3; $i++) {
             DB::table('entries')->insert([
-                'user_id' => $i+1,
+                'user_id' => $i+2, //id1,2は先生だからプラス2している
                 'company_id' => $i,
             ]);
         }

--- a/src/database/seeds/FavoritesTableSeeder.php
+++ b/src/database/seeds/FavoritesTableSeeder.php
@@ -14,7 +14,7 @@ class FavoritesTableSeeder extends Seeder
     {
         for ($i = 1; $i<=3; $i++) {
             DB::table('favorites')->insert([
-                'user_id' => $i+1, //id1は先生だからプラスしている
+                'user_id' => $i+2, //id1,2は先生だからプラス2している
                 'company_id' => $i,
             ]);
         }

--- a/src/database/seeds/ProgressTableSeeder.php
+++ b/src/database/seeds/ProgressTableSeeder.php
@@ -17,7 +17,7 @@ class ProgressTableSeeder extends Seeder
         $states = ['◯','◯','×'];
         for ($i = 1; $i<=3; $i++) {
             DB::table('progress')->insert([
-                'user_id' => $i+1, //id1は先生だからプラスしている
+                'user_id' => $i+2, //id1,2は先生だからプラス2している
                 'entry_id' => $i,
                 'action' => $actions[$i-1],
                 'state' => $states[$i-1],

--- a/src/database/seeds/UsersTableSeeder.php
+++ b/src/database/seeds/UsersTableSeeder.php
@@ -18,6 +18,12 @@ class UsersTableSeeder extends Seeder
             'password' => bcrypt('password'),
             'is_teacher' => 1,
         ]);
+        DB::table('users')->insert([
+            'name' => '先生太郎2',
+            'email' => 'teacher2@example.com',
+            'password' => bcrypt('password'),
+            'is_teacher' => 1,
+        ]);
 
         $students = ['田中太郎','山田太郎','佐藤太郎'];
         $emails = ['taro1@example.com','taro2@example.com','taro3@example.com'];
@@ -28,6 +34,19 @@ class UsersTableSeeder extends Seeder
                 'email' => $emails[$i],
                 'password' => bcrypt('password'),
                 'teacher_id' => 1,
+                'is_teacher' => 0,
+            ]);
+        }
+
+        $students = ['中田太郎','中田二郎','中田三郎'];
+        $emails = ['nakata1@example.com','nakata2@example.com','nakata3@example.com'];
+        for ($i = 0; $i<3; $i++) {
+            DB::table('users')->insert([
+                'attend_num' => $i+4,
+                'name' => $students[$i],
+                'email' => $emails[$i],
+                'password' => bcrypt('password'),
+                'teacher_id' => 2,
                 'is_teacher' => 0,
             ]);
         }

--- a/src/tests/Feature/Company/CreateTest.php
+++ b/src/tests/Feature/Company/CreateTest.php
@@ -17,11 +17,11 @@ class CreateTest extends TestCase
      *
      * @return void
      */
-    public function testUserCreatesCompany()
+    public function testStudentCreatesCompany()
     {
-        $user = User::find(3);
+        $student = User::where('is_teacher',0)->first();
         $response = $this
-            ->actingAs($user)
+            ->actingAs($student)
             ->get('companies/create');
         $response->assertStatus(200);
 
@@ -33,7 +33,27 @@ class CreateTest extends TestCase
 
         $this->assertDatabaseHas('companies', [
             'name' => '株式会社テスト',
-            'create_user_id' => $user->id,
+            'create_user_id' => $student->id,
+        ]);
+    }
+
+    public function testTeacherCreatesCompany()
+    {
+        $teacher = User::where('is_teacher',1)->first();
+        $response = $this
+            ->actingAs($teacher)
+            ->get('companies/create');
+        $response->assertStatus(200);
+
+        $today = Carbon::tomorrow('Asia/Tokyo');
+        $response = $this->post(route('companies.store'), ['name' => '株式会社テスト','prefecture' => '愛媛', 'url' => 'https://test.com', 'remarks' => 'なし','deadlind' => $today]);
+        // リダイレクトでページ遷移してくるのでstatusは302
+        $response->assertStatus(302);
+        $response->assertRedirect('/companies');
+
+        $this->assertDatabaseHas('companies', [
+            'name' => '株式会社テスト',
+            'create_user_id' => $teacher->id,
         ]);
     }
 

--- a/src/tests/Feature/Progress/CreateTest.php
+++ b/src/tests/Feature/Progress/CreateTest.php
@@ -14,21 +14,20 @@ class CreateTest extends TestCase
     use RefreshDatabase;
     public function testUserRegisterProgress()
     {
-        $user = User::find(2);
+        $student = User::where('is_teacher',0)->first();
         $company = Company::find(1);
         $response = $this
-            ->actingAs($user)
+            ->actingAs($student)
             ->get('companies/' . $company->id);
         $response->assertStatus(200);
 
         // 2個目登録（1個目はseederで作成済み）
         $response = $this->post(route('progress.store'), ['action' => '面接','state' => '◯', 'action_date' => '2021-06-10','company_id' => $company->id]);
-        // リダイレクトでページ遷移してくるのでstatusは302
         $response->assertStatus(302);
         $response->assertRedirect('companies/'.$company->id);
         $response->assertSessionHas("status", "進捗を登録しました。");
         $this->assertDatabaseHas('progress', [
-            'user_id' => $user->id,
+            'user_id' => $student->id,
             'entry_id' => 1,
             'action' => "面接",
             'state' => "◯",
@@ -50,15 +49,14 @@ class CreateTest extends TestCase
 
     public function testUserRegisterProgressNotEnterd()
     {
-        $user = User::find(2);
+        $student = User::where('is_teacher',0)->first();
         $company = Company::find(3);
         $response = $this
-            ->actingAs($user)
+            ->actingAs($student)
             ->get('companies/' . $company->id);
         $response->assertStatus(200);
 
         $response = $this->post(route('progress.store'), ['action' => '面接','state' => '◯', 'action_date' => '2021-06-10','company_id' => $company->id]);
-        // リダイレクトでページ遷移してくるのでstatusは302
         $response->assertStatus(302);
         $response->assertRedirect('companies/'.$company->id);
         $response->assertSessionHas("status-error", "エントリーしていないので進捗を登録できません。");
@@ -74,7 +72,6 @@ class CreateTest extends TestCase
         $response->assertStatus(200);
 
         $response = $this->post(route('progress.store'), ['action' => '面接','state' => '◯', 'action_date' => '2021-06-10','company_id' => $company->id]);
-        // リダイレクトでページ遷移してくるのでstatusは302
         $response->assertStatus(302);
         $response->assertRedirect('companies/'.$company->id);
         $response->assertSessionHas("status-error", "あなたは教師なので進捗登録できません。");
@@ -90,7 +87,6 @@ class CreateTest extends TestCase
         $response->assertStatus(200);
 
         $response = $this->post(route('progress.store'), ['action' => '','state' => '', 'action_date' => '','company_id' => '']);
-        // リダイレクトでページ遷移してくるのでstatusは302
         $response->assertStatus(302);
         $response->assertRedirect('companies/'.$company->id);
         $response->assertSessionHasErrors(['action' => '活動内容は必須です。','state' => '状態は必須です。','action_date'=>'実施日は必須です。','company_id'=>'会社詳細ページから登録してください。']);
@@ -106,7 +102,6 @@ class CreateTest extends TestCase
         $response->assertStatus(200);
 
         $response = $this->post(route('progress.store'), ['action' => '第一次面接','state' => '▽', 'action_date' => '2020/444/2323','company_id' => $company->id]);
-        // リダイレクトでページ遷移してくるのでstatusは302
         $response->assertStatus(302);
         $response->assertRedirect('companies/'.$company->id);
         $response->assertSessionHasErrors(['action' => '選択欄からお選びください。','state' => '選択欄からお選びください。','action_date'=>'日にちを入力してください。']);

--- a/src/tests/Feature/Progress/DestroyTest.php
+++ b/src/tests/Feature/Progress/DestroyTest.php
@@ -15,10 +15,10 @@ class DestroyTest extends TestCase
     use RefreshDatabase;
     public function testDeleteProgress()
     {
-        $user = User::find(2);
+        $student = User::where('is_teacher',0)->first();
         $company = Company::find(1);
         $response = $this
-            ->actingAs($user)
+            ->actingAs($student)
             ->get('companies/' . $company->id);
         $progress = Progress::find(1);
         $response->assertStatus(200);
@@ -33,10 +33,10 @@ class DestroyTest extends TestCase
 
     public function testDeleteProgressUnregisterProgress()
     {
-        $user = User::find(2);
+        $student = User::where('is_teacher',0)->first();
         $company = Company::find(1);
         $response = $this
-            ->actingAs($user)
+            ->actingAs($student)
             ->get('companies/' . $company->id);
         $response->assertStatus(200);
 
@@ -48,10 +48,10 @@ class DestroyTest extends TestCase
 
     public function testDeleteOtherUserProgress()
     {
-        $user = User::find(2);
+        $student = User::where('is_teacher',0)->first();
         $company = Company::find(1);
         $response = $this
-            ->actingAs($user)
+            ->actingAs($student)
             ->get('companies/' . $company->id);
         $response->assertStatus(200);
 

--- a/src/tests/Feature/Progress/UpdateTest.php
+++ b/src/tests/Feature/Progress/UpdateTest.php
@@ -15,20 +15,19 @@ class UpdateTest extends TestCase
     use RefreshDatabase;
     public function testUserUpdateProgress()
     {
-        $user = User::find(2);
+        $student = User::where('is_teacher',0)->first();
         $company = Company::find(1);
         $response = $this
-            ->actingAs($user)
+            ->actingAs($student)
             ->get('companies/' . $company->id);
         $response->assertStatus(200);
 
         $response = $this->put(route('progress.update',['progress' => 1]), ['state' => '欠席', 'action_date' => '2021-06-10','company_id' => $company->id]);
-        // リダイレクトでページ遷移してくるのでstatusは302
         $response->assertStatus(302);
         $response->assertRedirect('companies/'.$company->id);
         $response->assertSessionHas("status", "進捗を変更しました。");
         $this->assertDatabaseHas('progress', [
-            'user_id' => $user->id,
+            'user_id' => $student->id,
             'entry_id' => 1,
             'action' => "会社説明会",
             'state' => "欠席",
@@ -37,15 +36,14 @@ class UpdateTest extends TestCase
 
     public function testUserUpdateProgressUnregisterProgress()
     {
-        $user = User::find(2);
+        $student = User::where('is_teacher',0)->first();
         $company = Company::find(1);
         $response = $this
-            ->actingAs($user)
+            ->actingAs($student)
             ->get('companies/' . $company->id);
         $response->assertStatus(200);
 
         $response = $this->put(route('progress.update',['progress' => 3]), ['state' => '欠席', 'action_date' => '2021-06-10','company_id' => $company->id]);
-        // リダイレクトでページ遷移してくるのでstatusは302
         $response->assertStatus(302);
         $response->assertRedirect('companies/'.$company->id);
         $response->assertSessionHas("status-error", "進捗が登録されていないのでこの処理はできません。");
@@ -53,15 +51,14 @@ class UpdateTest extends TestCase
 
     public function testUserUpdateProgressNotEnterd()
     {
-        $user = User::find(2);
+        $student = User::where('is_teacher',0)->first();
         $company = Company::find(3);
         $response = $this
-            ->actingAs($user)
+            ->actingAs($student)
             ->get('companies/' . $company->id);
         $response->assertStatus(200);
 
         $response = $this->put(route('progress.update',['progress' => 1]), ['state' => '欠席', 'action_date' => '2021-06-10','company_id' => $company->id]);
-        // リダイレクトでページ遷移してくるのでstatusは302
         $response->assertStatus(302);
         $response->assertRedirect('companies/'.$company->id);
         $response->assertSessionHas("status-error", "エントリーしていないのでこの処理はできません。");
@@ -77,7 +74,6 @@ class UpdateTest extends TestCase
         $response->assertStatus(200);
 
         $response = $this->put(route('progress.update',['progress' => 1]), ['state' => '欠席', 'action_date' => '2021-06-10','company_id' => $company->id]);
-        // リダイレクトでページ遷移してくるのでstatusは302
         $response->assertStatus(302);
         $response->assertRedirect('companies/'.$company->id);
         $response->assertSessionHas("status-error", "あなたは教師なのでこの処理はできません。");
@@ -93,7 +89,6 @@ class UpdateTest extends TestCase
         $response->assertStatus(200);
 
         $response = $this->put(route('progress.update',['progress' => 1]), ['state' => '', 'action_date' => '','company_id' => '']);
-        // リダイレクトでページ遷移してくるのでstatusは302
         $response->assertStatus(302);
         $response->assertRedirect('companies/'.$company->id);
         $response->assertSessionHasErrors(['state' => '状態は必須です。','action_date'=>'実施日は必須です。','company_id'=>'会社詳細ページから変更してください。']);
@@ -109,7 +104,6 @@ class UpdateTest extends TestCase
         $response->assertStatus(200);
 
         $response = $this->put(route('progress.update',['progress' => 1]), ['state' => '▽', 'action_date' => '2020/444/2323','company_id' => "aaa"]);
-        // リダイレクトでページ遷移してくるのでstatusは302
         $response->assertStatus(302);
         $response->assertRedirect('companies/'.$company->id);
         $response->assertSessionHasErrors(['state' => '選択欄からお選びください。','action_date'=>'日にちを入力してください。','company_id'=>'会社IDが不正です。']);

--- a/src/tests/Feature/User/CreateTest.php
+++ b/src/tests/Feature/User/CreateTest.php
@@ -29,11 +29,43 @@ class CreateTest extends TestCase
         // リダイレクトでページ遷移してくるのでstatusは302
         $response->assertStatus(302);
         $response->assertRedirect('/home');
+        $response->assertSessionHas("status", "生徒（User作成テスト太郎）を登録しました。");
 
         $this->assertDatabaseHas('users', [
             'email' => 'taro4@example.com',
             'is_teacher' => 0,
             'teacher_id' => $teacher->id,
+        ]);
+    }
+
+    public function testTeacherCreatesDeletedStudent()
+    {
+        $teacher = User::where('is_teacher',1)->first();
+        $student = User::where('is_teacher',0)->where('teacher_id',$teacher->id)->first();
+        $response = $this
+            ->actingAs($teacher)
+            ->assertAuthenticatedAs($teacher);
+        // 生徒を削除
+        $response = $this->delete(route('users.destroy',['user' => $student->id]));
+        $response->assertStatus(302);
+        $this->assertSoftDeleted('users', [
+            'id' => $student->id,
+            'email' => $student->email,
+        ]);
+
+        $response = $this
+        ->get('users/create');
+        $response->assertStatus(200);
+
+        $response = $this->post(route('users.store'), ['attend_num' =>$student->id,'name' => $student->name ,'email' => $student->email, 'password' => $student->password, 'password_confirmation' => $student->password]);
+        // リダイレクトでページ遷移してくるのでstatusは302
+        $response->assertStatus(302);
+        $response->assertRedirect('/home');
+        $response->assertSessionHas("status", "生徒（" . $student->name . "）を復元しました。");
+
+        $this->assertDatabaseHas('users', [
+            'email' => $student->email,
+            'deleted_at' => NULL,
         ]);
     }
 

--- a/src/tests/Feature/User/DestroyTest.php
+++ b/src/tests/Feature/User/DestroyTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\User;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Auth;
+use Tests\TestCase;
+use App\User;
+
+class DestroyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function TeacherDeletesStudent()
+    {
+        $teacher = User::where('is_teacher',1)->first();
+        $student = User::where('is_teacher',0)->where('teacher_id',$teacher->id)->first();
+        $response = $this
+            ->actingAs($teacher)
+            ->assertAuthenticatedAs($teacher);
+
+        $response = $this->delete(route('users.destroy',['user' => $student->id]));
+        $response->assertStatus(302);
+        $response->assertSessionHas("status", "生徒（" . $student->name . "）を削除しました。");
+
+        $this->assertSoftDeleted('users', [
+            'id' => $student->id,
+            'email' => $student->email,
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function TeacherDeletesUserNotHisStudent()
+    {
+        $teacher = User::where('is_teacher',1)->first();
+        $student = User::where('is_teacher',0)->where('teacher_id','!=',$teacher->id)->first();
+        $response = $this
+            ->actingAs($teacher)
+            ->assertAuthenticatedAs($teacher);
+
+        $response = $this->delete(route('users.destroy',['user' => $student->id]));
+        $response->assertStatus(302);
+        $response->assertSessionHas("status-error", "削除対象の生徒が自分の生徒ではない為、処理が失敗しました。");
+
+        $this->assertDatabaseHas('users', [
+            'id' => $student->id,
+            'deleted_at' => NULL,
+        ]);
+    }
+    /**
+     * @test
+     */
+    public function TeacherDeletesNotExsistsStudent()
+    {
+        $teacher = User::where('is_teacher',1)->first();
+        $response = $this
+            ->actingAs($teacher)
+            ->assertAuthenticatedAs($teacher);
+        // 存在しないユーザID（999999）の生徒を削除
+        $response = $this->delete(route('users.destroy',['user' => 999999]));
+        $response->assertStatus(302);
+        $response->assertSessionHas("status-error", "削除対象の生徒が存在しない為、処理が失敗しました。");
+    }
+
+    /**
+     * @test
+     */
+    public function StudentDeletesStudent()
+    {
+        $student = User::where('is_teacher',0)->first();
+        $student_to_be_deleted = User::where('is_teacher',0)->where('id','!=',$student->id)->first();
+        $response = $this
+            ->actingAs($student)
+            ->assertAuthenticatedAs($student);
+        // 生徒が生徒を削除(失敗)
+        $response = $this->delete(route('users.destroy',['user' => $student_to_be_deleted->id]));
+        $response->assertStatus(302)
+                ->assertRedirect('home');
+
+        $this->assertDatabaseHas('users', [
+            'id' => $student_to_be_deleted->id,
+            'deleted_at' => NULL,
+        ]);
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        Artisan::call('migrate:refresh');
+        Artisan::call('db:seed');
+    }
+}


### PR DESCRIPTION
Changes
1. UserControllerにdestroy処理追加
2. ユーザー削除は論理削除の為、ユーザー作成時に論理削除されているユーザーを復元するようにUserController/storeを修正
3. UserControllerDestroyのTestを作成
4. ユーザー作成機能のTestに論理削除されている場合のテストを追加
5. 3を作成実行するにあたり、seederの変更が必要だった為、seederを変更
6. 5のseederの変更にあたり、他のTestがエラーになった為、エラーになったTestを修正